### PR TITLE
Fix unescaped `<fun>`

### DIFF
--- a/courses/focs-fa18/homeworks/h2.html
+++ b/courses/focs-fa18/homeworks/h2.html
@@ -455,7 +455,7 @@ li ul {margin-top:6px;}
   <p onClick="toggleShowHide(this)">Show sample output</p>
 <pre>
 # set_loc [("X",10)] "X";;
-- : int -> config = <fun>
+- : int -> config = &lt;fun&gt;
 # set_loc [("X",10)] "X" 42;;
 - : config = [("X", 42)]
 # set_loc [("X",10);("Y",20)] "X" 42;;


### PR DESCRIPTION

On section 1C the example output seemed to be missing something. On closer inspection the `<fun>` from the second line `- : int -> config = <fun>` was unescaped and misinterpreted by the browser.

The current appearance:
![image](https://user-images.githubusercontent.com/10699964/45603558-f9e07700-b9fa-11e8-8474-6eef13da53b7.png)

Firefox interprets this as a \<fun\> element without a closing tag and tries to correct it:
![image](https://user-images.githubusercontent.com/10699964/45603572-1d0b2680-b9fb-11e8-87c2-a2a7c38c619e.png)

After escaping the angle brackets:
![image](https://user-images.githubusercontent.com/10699964/45603641-b1758900-b9fb-11e8-9ec6-f3637f4b7f85.png)
